### PR TITLE
fix(serialize): stop collapsing single-element lists to their bare element

### DIFF
--- a/emodeconnection/types.py
+++ b/emodeconnection/types.py
@@ -24,8 +24,6 @@ def serialize(data: Any):
             data[key] = serialize(value)
         return data
     elif isinstance(data, list):
-        if len(data) == 1:
-            return serialize(data[0])
         return [serialize(item) for item in data]
     elif isinstance(data, np.floating):
         return float(data)


### PR DESCRIPTION
## Summary

`serialize()` (used by the client when sending call arguments to the server) silently unwrapped any single-element list to just that element before JSON-encoding it — so `some_function(list_param=[x])` arrived server-side as `list_param=x`, not `list_param=[x]`, for *every* list-typed argument anywhere in the call tree. Found while integrating the public Ports API (`emode-photonix/emode` #143/#146) — `ports=[Port(...)]` was arriving server-side as a bare `Port` object instead of a one-item list.

This was live-breaking several `EM_*` functions today whenever a caller passed a single-item list where one is a completely normal, documented input:
- `EM_gds_section`/`EM_straight_section`/etc.'s `ports=`
- `EM_EME_settings(apply_scattering=[wl])`
- `EM_create_profile_set(profiles=[name])` — silently exploded the string into individual characters (`list('my_profile')`)
- `EM_sweep`'s single-value length sweeps

Full audit of every `EM_*` function's list-shaped parameters (what's already safe, what would newly break, what's already broken independent of this) is in the companion emode-linux PR's description.

## Test plan
- [x] Direct check: `serialize({'ports': [{'a': 1}]})` now returns `{'ports': [{'a': 1}]}` (list preserved) instead of `{'ports': {'a': 1}}`
- [x] Verified against the companion `emode-photonix/emode` PR's full test suite (6301 passed, same 3 pre-existing/flaky failures as before this change)
- [x] No test suite exists in this repo to run directly — verified via the emode-linux side's simulated client→server wire round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)