### PR TITLE
feat(ports): add Port.offset for content displacement

### DIFF
--- a/emodeconnection/port.py
+++ b/emodeconnection/port.py
@@ -55,6 +55,20 @@ class Port(TaggedModel):
     `[Port('left', None, 'left'), Port('right', None, 'right')]`. Supplying
     a port in `EM_<x>_section(ports=[...])` replaces every existing port on
     the same `side`; multiple ports may share a side.
+
+    A `Port` carries two offsets that mean different things, and mixing them
+    up is easy:
+
+    - `window.offset` locates the sub-window *inside this section's own
+      cross-section*. It selects which material the port exposes; it does not
+      move the section relative to anything.
+    - `offset` (below) is a **content displacement**: it says where this
+      section's cross-section sits relative to whatever the port is connected
+      to. Connecting two ports pins their origins together (the point
+      `(x_center, y_min)` of each port's cross-section), and `offset` shifts
+      this side's content off that shared origin.
+
+    So `window` answers "which part of me?" and `offset` answers "where am I?".
     """
     model_config = ConfigDict(frozen=True)
 
@@ -62,6 +76,10 @@ class Port(TaggedModel):
     window: Bounds | None = None
     side: Literal['left', 'right']
     basis_transform: BasisTransform | None = None
+    # Content displacement of this section relative to the port it connects
+    # to, in nm: `offset=(1300, 0)` moves this section's cross-section +1300
+    # in x from the connection's shared origin.
+    offset: tuple[float, float] = (0.0, 0.0)
 
 
 def make_angled_facet_port(


### PR DESCRIPTION
Wire-type half of port coordinate pinning. Pairs with **emode-linux `port-offset-pinning`**, which carries the model, the implementation and the tests — this repo only gains the field the server reads.

Based on `fix-single-item-list-collapse` (#29), not `dev`, since the Ports API wire types live there.

## What

`Port` gains one field:

```python
offset: tuple[float, float] = (0.0, 0.0)
```

Connecting two ports pins their coordinate systems together: the two ports' origins — `(x_center, y_min)` of each cross-section — are made to coincide, so the connection is what positions one section relative to the other. `offset` displaces a section off that shared origin.

## Why the docstring is long

A `Port` now carries **two** offsets that mean different things, and conflating them was the bug this change fixes on the server side:

- `window.offset` locates the sub-window *inside this section's own cross-section*. It selects which material the port exposes; it never moves the section.
- `offset` is a **content displacement** relative to whatever the port is connected to.

Short version, which is in the docstring: `window` answers *"which part of me?"*, `offset` answers *"where am I?"*.

## Compatibility

- Added last, with a default, so old EPH pickles and existing `Port(...)` calls are unaffected.
- `Port` is a frozen `TaggedModel`; verified the field round-trips through `object_from_dict` with its `__data_type__` tag intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)