### PR TITLE
fix(port): use TypeAlias, not the PEP 695 type statement (3.12-only)

### DIFF
--- a/emodeconnection/port.py
+++ b/emodeconnection/port.py
@@ -6,7 +6,7 @@ addressable globally as `"<section_name>.<port_name>"` (see
 modal transform; `AngledFacetMap` (a per-mode linear phase ramp about a
 hinge line, modeling an angled facet) is the first thing that can go in it.
 """
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict
 
@@ -42,9 +42,11 @@ class AngledFacetMap(TaggedModel):
 
 
 # v1 has exactly one member. A plain alias (not yet a real union) keeps it
-# trivially extensible later: `type BasisTransform = AngledFacetMap | ModeSelectMap | ...`
-# without ever changing Port's type signature.
-type BasisTransform = AngledFacetMap
+# trivially extensible later: `BasisTransform: TypeAlias = AngledFacetMap | ModeSelectMap | ...`
+# without ever changing Port's type signature. `typing.TypeAlias` (PEP 613,
+# not the PEP 695 `type` statement) -- this package supports Python 3.10+,
+# and `type X = ...` is 3.12-only syntax.
+BasisTransform: TypeAlias = AngledFacetMap
 
 
 @register_type


### PR DESCRIPTION
## Summary

\`type BasisTransform = AngledFacetMap\` in \`emodeconnection/port.py\` is a hard `SyntaxError` on Python 3.10/3.11 -- this package declares \`requires-python = ">=3.10"\`, and the PEP 695 statement form of type aliases is Python 3.12-only syntax (not deferred by \`from __future__ import annotations\` the way annotation-only syntax is).

Reproduced against a real 3.10.16 interpreter before fixing. \`typing.TypeAlias\` (PEP 613, available since 3.10) is the portable equivalent -- same explicit "this is a type" declaration, works everywhere the package claims to support.

Note: this branch (\`port-offset-pinning\`) was already merged into \`dev\` via #30; this PR only adds the one fix commit on top, so the diff is just the one file.

## Test plan
- Reproduced the `SyntaxError` on a real Python 3.10.16 interpreter, confirmed the fix parses cleanly there.
- Re-imported `BasisTransform`/`AngledFacetMap` on the normal (3.12) dev venv -- unchanged behavior.
- Ran `emode-linux`'s `test/test_serialization_2.py` (references these wire types): 92 passed, 14 skipped, no regressions.
- Scanned the whole repo for other PEP 695 syntax (`type X = ...`, `class X[T]`, `def f[T]`) -- this was the only instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)